### PR TITLE
Fix BroadcastGlobalVariablesHook() parameter name

### DIFF
--- a/TensorFlow/Classification/ConvNets/runtime/runner.py
+++ b/TensorFlow/Classification/ConvNets/runtime/runner.py
@@ -421,7 +421,7 @@ class Runner(object):
             training_hooks.append(self.training_logging_hook)
 
         if hvd_utils.is_using_hvd():
-            bcast_hook = hvd.BroadcastGlobalVariablesHook(root=0)
+            bcast_hook = hvd.BroadcastGlobalVariablesHook(0)
             training_hooks.append(bcast_hook)
 
         training_hooks.append(hooks.PrefillStagingAreasHook())
@@ -447,10 +447,10 @@ class Runner(object):
             'symmetric': symmetric,
             'quant_delay': quant_delay
         }
-        
+
         if finetune_checkpoint:
            estimator_params['finetune_checkpoint']=finetune_checkpoint
-        
+
         image_classifier = self._get_estimator(
             mode='train',
             run_params=estimator_params,

--- a/TensorFlow/Detection/SSD/models/research/object_detection/model_lib.py
+++ b/TensorFlow/Detection/SSD/models/research/object_detection/model_lib.py
@@ -703,7 +703,7 @@ def create_train_and_eval_specs(train_input_fn,
   train_spec = tf.estimator.TrainSpec(
       input_fn=train_input_fn,
       max_steps=train_steps // hvd.size(), # no `steps' attribute; only max_steps available
-      hooks=[hvd.BroadcastGlobalVariablesHook(root=0)])
+      hooks=[hvd.BroadcastGlobalVariablesHook(0)])
 
   if eval_spec_names is None:
     eval_spec_names = [str(i) for i in range(len(eval_input_fns))]

--- a/TensorFlow/Detection/SSD/models/research/object_detection/model_main.py
+++ b/TensorFlow/Detection/SSD/models/research/object_detection/model_main.py
@@ -181,7 +181,7 @@ def main(unused_argv):
         train_steps,
         eval_on_train_data=False)
 
-    train_hooks = [hvd.BroadcastGlobalVariablesHook(root=0), DLLoggerHook(hvd.size()*train_and_eval_dict['train_batch_size'], hvd.rank())]
+    train_hooks = [hvd.BroadcastGlobalVariablesHook(0), DLLoggerHook(hvd.size()*train_and_eval_dict['train_batch_size'], hvd.rank())]
     eval_hooks = []
 
     for x in range(FLAGS.eval_count):

--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
@@ -72,7 +72,7 @@ def get_training_hooks(mode, model_dir, checkpoint_path=None, skip_checkpoint_va
         ))
 
     if MPI_is_distributed() and mode == "train":
-        training_hooks.append(hvd.BroadcastGlobalVariablesHook(root=0))
+        training_hooks.append(hvd.BroadcastGlobalVariablesHook(0))
 
     if not MPI_is_distributed() or MPI_rank() == 0:
         training_hooks.append(CheckpointSaverHook(


### PR DESCRIPTION
- There was a change in BroadcastGlobalVariablesHook() parameter name from `root` to `root_rank` in this PR (https://github.com/aws/herring/pull/259). Fixing those here.