### PR TITLE
Remove references to PY3 attribute for PT 1.8 update

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
@@ -132,7 +132,7 @@ def _rename_weights_for_resnet(weights, stage_names):
 
 def _load_c2_pickled_weights(file_path):
     with open(file_path, "rb") as f:
-        if torch._six.PY3:
+        if torch._six.PY37:
             data = pickle.load(f, encoding="latin1")
         else:
             data = pickle.load(f)

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
@@ -132,12 +132,10 @@ def _rename_weights_for_resnet(weights, stage_names):
 
 def _load_c2_pickled_weights(file_path):
     with open(file_path, "rb") as f:
-        #if torch._six.PY37:
+        data = pickle.load(f, encoding="latin1") #if torch._six.PY37:
         #    data = pickle.load(f, encoding="latin1")
         #else:
         #    data = pickle.load(f)
-        print("HERE")
-        data = pickle.load(f, encoding="latin1")
     if "blobs" in data:
         weights = data["blobs"]
     else:

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
@@ -1,4 +1,5 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+import sys
 import logging
 import pickle
 from collections import OrderedDict
@@ -132,10 +133,10 @@ def _rename_weights_for_resnet(weights, stage_names):
 
 def _load_c2_pickled_weights(file_path):
     with open(file_path, "rb") as f:
-        data = pickle.load(f, encoding="latin1") #if torch._six.PY37:
-        #    data = pickle.load(f, encoding="latin1")
-        #else:
-        #    data = pickle.load(f)
+        if sys.version_info[0] == 3:
+            data = pickle.load(f, encoding="latin1")
+        else:
+            data = pickle.load(f)
     if "blobs" in data:
         weights = data["blobs"]
     else:

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
@@ -136,8 +136,8 @@ def _load_c2_pickled_weights(file_path):
         #    data = pickle.load(f, encoding="latin1")
         #else:
         #    data = pickle.load(f)
-	print("HERE")
-	data = pickle.load(f, encoding="latin1")
+        print("HERE")
+        data = pickle.load(f, encoding="latin1")
     if "blobs" in data:
         weights = data["blobs"]
     else:

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
@@ -136,6 +136,7 @@ def _load_c2_pickled_weights(file_path):
         #    data = pickle.load(f, encoding="latin1")
         #else:
         #    data = pickle.load(f)
+	print("HERE")
 	data = pickle.load(f, encoding="latin1")
     if "blobs" in data:
         weights = data["blobs"]

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/c2_model_loading.py
@@ -132,10 +132,11 @@ def _rename_weights_for_resnet(weights, stage_names):
 
 def _load_c2_pickled_weights(file_path):
     with open(file_path, "rb") as f:
-        if torch._six.PY37:
-            data = pickle.load(f, encoding="latin1")
-        else:
-            data = pickle.load(f)
+        #if torch._six.PY37:
+        #    data = pickle.load(f, encoding="latin1")
+        #else:
+        #    data = pickle.load(f)
+	data = pickle.load(f, encoding="latin1")
     if "blobs" in data:
         weights = data["blobs"]
     else:

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/imports.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/imports.py
@@ -1,7 +1,7 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 import torch
 
-if torch._six.PY3:
+if torch._six.PY37:
     import importlib
     import importlib.util
     import sys

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/imports.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/imports.py
@@ -1,7 +1,8 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
+import sys
 import torch
 
-if torch._six.PY37:
+if sys.version_info[0] == 3:
     import importlib
     import importlib.util
     import sys


### PR DESCRIPTION
PyTorch 1.8.0 no longer has the attribute `_six.PY3`, only `PY37`. `PY3` was set to `sys.version_info[0] == 3` in previous PT versions. 

Tested to make sure this worked by running Mask RCNN training on EC2