### PR TITLE
[canary] Fixed TF2 mrcnn bucket issue

### DIFF
--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/hyperparameters/cmdline_utils.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/hyperparameters/cmdline_utils.py
@@ -176,4 +176,6 @@ def define_hparams_flags():
         help='Enable XLA JIT Compiler at Inference'
     )
 
+    flags.DEFINE_integer('bucket_cap_mb', default=64, help='Set the bucket size in mb')
+
     return flags.FLAGS


### PR DESCRIPTION
- TF2 Mask RCNN canaries started failing due to recently added feature of command line `bucket_cap_mb`. This PR fixes that issue.