### PR TITLE
PT SSD bug fix for coco data setup

### DIFF
--- a/PyTorch/Detection/SSD/src/coco_pipeline.py
+++ b/PyTorch/Detection/SSD/src/coco_pipeline.py
@@ -236,7 +236,7 @@ class DALICOCOIterator(object):
                 for k in range(len(l_list)):
                     if (pyt_labels[j][k].shape[0] != 0):
                         feed_ndarray(l_list[k], pyt_labels[j][k])
-                pyt_labels[j] = torch.cat(pyt_labels[j]).squeeze(dim=1)
+                pyt_labels[j] = torch.cat(pyt_labels[j])
 
             for j in range(len(pyt_offsets)):
                 pyt_offsets[j] = torch.IntTensor(bbox_offsets[j])


### PR DESCRIPTION
Bug fix for
```
[1,5]<stdout>:  File "/shared/DeepLearningExamples/PyTorch/Detection/SSD/src/coco_pipeline.py", line 239, in __next__
[1,5]<stdout>:    pyt_labels[j] = torch.cat(pyt_labels[j]).squeeze(dim=1)
[1,5]<stdout>:IndexError: Dimension out of range (expected to be in range of [-1, 0], but got 1)
```