### PR TITLE
Use EFA for PT DDP maskrcnn and bert

### DIFF
--- a/PyTorch/LanguageModeling/BERT/run_pretraining_nccl_sm.py
+++ b/PyTorch/LanguageModeling/BERT/run_pretraining_nccl_sm.py
@@ -10,6 +10,7 @@ import json
 
 os.environ['HDF5_USE_FILE_LOCKING'] = 'FALSE'
 os.environ['NCCL_DEBUG'] = 'INFO'
+os.environ['FI_EFA_USE_DEVICE_RDMA'] = '1'
 
 
 def parse_args():

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/tools/train_net_sm.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/tools/train_net_sm.py
@@ -7,6 +7,7 @@ import shutil
 import json
 
 os.environ['NCCL_DEBUG'] = 'INFO'
+os.environ['FI_EFA_USE_DEVICE_RDMA'] = '1'
 
 def main():
     parser = argparse.ArgumentParser(description="PyTorch Object Detection Training")


### PR DESCRIPTION
For apples-to-apples comparison in weekly benchmarking report, NCCL runs should also be using EFA. 