### PR TITLE
PT MaskRCNN to use native amp

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/config/defaults.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/config/defaults.py
@@ -319,7 +319,7 @@ _C.PATHS_CATALOG = os.path.join(os.path.dirname(__file__), "paths_catalog.py")
 _C.DTYPE = "float32"
 
 # Enable verbosity in apex.amp
-_C.AMP_VERBOSE = False
+# _C.AMP_VERBOSE = False
 
 # Evaluate every epoch
 _C.PER_EPOCH_EVAL = False

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/layers/nms.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/layers/nms.py
@@ -3,10 +3,10 @@
 # from ._utils import _C
 from maskrcnn_benchmark import _C
 
-from apex import amp
+from torch.cuda.amp import custom_fwd
 
 # Only valid with fp32 inputs - give AMP the hint
-nms = amp.float_function(_C.nms)
+nms = custom_fwd(_C.nms)
 
 # nms.__doc__ = """
 # This function performs Non-maximum suppresion"""

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/layers/roi_align.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/layers/roi_align.py
@@ -8,8 +8,6 @@ from torch.nn.modules.utils import _pair
 
 from maskrcnn_benchmark import _C
 
-from apex import amp
-
 class _ROIAlign(Function):
     @staticmethod
     def forward(ctx, input, roi, output_size, spatial_scale, sampling_ratio):
@@ -55,7 +53,7 @@ class ROIAlign(nn.Module):
         self.spatial_scale = spatial_scale
         self.sampling_ratio = sampling_ratio
 
-    @amp.float_function
+    @torch.cuda.amp.custom_fwd(cast_inputs=torch.float32)
     def forward(self, input, rois):
         return roi_align(
             input, rois, self.output_size, self.spatial_scale, self.sampling_ratio

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/layers/roi_pool.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/layers/roi_pool.py
@@ -7,8 +7,6 @@ from torch.nn.modules.utils import _pair
 
 from maskrcnn_benchmark import _C
 
-from apex import amp
-
 class _ROIPool(Function):
     @staticmethod
     def forward(ctx, input, roi, output_size, spatial_scale):
@@ -53,7 +51,7 @@ class ROIPool(nn.Module):
         self.output_size = output_size
         self.spatial_scale = spatial_scale
 
-    @amp.float_function
+    @torch.cuda.amp.custom_fwd(cast_inputs=torch.float32)
     def forward(self, input, rois):
         return roi_pool(input, rois, self.output_size, self.spatial_scale)
 

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/tools/train_net.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/tools/train_net.py
@@ -39,17 +39,6 @@ from maskrcnn_benchmark.utils.logger import format_step
 import dllogger
 from maskrcnn_benchmark.utils.logger import format_step
 
-# See if we can use apex.DistributedDataParallel instead of the torch default,
-# and enable mixed-precision via apex.amp
-try:
-    from apex import amp
-    use_amp = True
-except ImportError:
-    print('Use APEX for multi-precision via apex.amp')
-    use_amp = False
-
-use_apex_ddp = False
-
 def test_and_exchange_map(tester, model, distributed):
     results = tester(model=model, distributed=distributed)
 
@@ -99,15 +88,11 @@ def train(cfg, local_rank, distributed, fp16, dllogger, data_dir, bucket_cap_mb)
     optimizer = make_optimizer(cfg, model)
     scheduler = make_lr_scheduler(cfg, optimizer)
 
-    if use_amp:
-        # Initialize mixed-precision training
-        if fp16:
-            use_mixed_precision = True
-        else:
-            use_mixed_precision = cfg.DTYPE == "float16"
-
-        amp_opt_level = 'O1' if use_mixed_precision else 'O0'
-        model, optimizer = amp.initialize(model, optimizer, opt_level=amp_opt_level)
+    use_amp = False
+    if fp16:
+        use_amp = True
+    else:
+        use_amp = cfg.DTYPE == "float16"
 
     if distributed:
         # Nvidia uses broadcast_buffers=False and said it will be removed if they update BatchNorm stats

--- a/PyTorch/Segmentation/MaskRCNN/requirements.sh
+++ b/PyTorch/Segmentation/MaskRCNN/requirements.sh
@@ -5,13 +5,13 @@ pip install ninja yacs cython matplotlib tqdm opencv-python pybind11==2.5.0 'git
 
 pip --no-cache-dir --no-cache install 'git+https://github.com/NVIDIA/cocoapi#egg=pycocotools&subdirectory=PythonAPI'
 
-cd $WORK_DIR
-git clone https://github.com/NVIDIA/apex; cd apex;
-python setup.py install --cuda_ext --cpp_ext
+#cd $WORK_DIR
+#git clone https://github.com/NVIDIA/apex; cd apex;
+#python setup.py install --cuda_ext --cpp_ext
 
 cd /shared/DeepLearningExamples/PyTorch/Segmentation/MaskRCNN/pytorch/
 python setup.py build develop
 
 wget https://dl.fbaipublicfiles.com/detectron/ImageNetPretrained/MSRA/R-50.pkl -P /root/.torch/models/
 
-rm -rf $WORK_DIR
+#rm -rf $WORK_DIR


### PR DESCRIPTION
PT1.10 breaks the MaskRCNN script when using Apex AMP with this error:
```
 File "/opt/conda/lib/python3.8/site-packages/apex/amp/utils.py", line 97, in cached_cast
  if cached_x.grad_fn.next_functions[1][0].variable is not x:
IndexError: tuple index out of range
```

Nvidia/DeepLearningExamples updated maskrcnn script to use native AMP instead of Apex AMP. 