### PR TITLE
[nccl] Fix multi-nodes mask-rcnn training 

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/comm.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/comm.py
@@ -31,6 +31,10 @@ def is_main_process():
     return get_rank() == 0
 
 
+def is_local_main_process():
+    return dist.get_local_rank() == 0
+
+
 def synchronize():
     """
     Helper function to synchronize (barrier) among all processes when

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/model_zoo.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/model_zoo.py
@@ -11,7 +11,7 @@ except:
     from torch.hub import urlparse
     from torch.hub import HASH_REGEX
 
-from maskrcnn_benchmark.utils.comm import is_main_process
+from maskrcnn_benchmark.utils.comm import is_local_main_process
 from maskrcnn_benchmark.utils.comm import synchronize
 
 
@@ -37,7 +37,7 @@ def cache_url(url, model_dir=None, progress=True):
     if model_dir is None:
         torch_home = os.path.expanduser(os.getenv('TORCH_HOME', '~/.torch'))
         model_dir = os.getenv('TORCH_MODEL_ZOO', os.path.join(torch_home, 'models'))
-    if not os.path.exists(model_dir) and is_main_process():
+    if not os.path.exists(model_dir) and is_local_main_process():
         os.makedirs(model_dir)
     parts = urlparse(url)
     filename = os.path.basename(parts.path)
@@ -46,7 +46,7 @@ def cache_url(url, model_dir=None, progress=True):
         # so make the full path the filename by replacing / with _
         filename = parts.path.replace("/", "_")
     cached_file = os.path.join(model_dir, filename)
-    if not os.path.exists(cached_file) and is_main_process():
+    if not os.path.exists(cached_file) and is_local_main_process():
         sys.stderr.write('Downloading: "{}" to {}\n'.format(url, cached_file))
         hash_prefix = HASH_REGEX.search(filename)
         if hash_prefix is not None:


### PR DESCRIPTION
The training script fails to download model weights in multi-nodes setup since it depends on `is_main_process`. This PR fix the issue by changing it to `is_local_main_process`. In master branch, the same issue was fixed by #49 