### PR TITLE
[nccl] Fix s3 support for TF 2.6 mask-rcnn

### DIFF
--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/dataloader.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/dataloader.py
@@ -201,11 +201,12 @@ class InputReader(object):
         data_options.experimental_optimization.map_fusion = True
         data_options.experimental_optimization.map_parallelization = True
 
-        map_vectorization_options = tf.data.experimental.MapVectorizationOptions()
-        map_vectorization_options.enabled = True
-        map_vectorization_options.use_choose_fastest = True
+        if LooseVersion(tf.__version__) < LooseVersion("2.6"):
+            map_vectorization_options = tf.data.experimental.MapVectorizationOptions()
+            map_vectorization_options.enabled = True
+            map_vectorization_options.use_choose_fastest = True
 
-        data_options.experimental_optimization.map_vectorization = map_vectorization_options
+            data_options.experimental_optimization.map_vectorization = map_vectorization_options
 
         data_options.experimental_optimization.noop_elimination = True
         data_options.experimental_optimization.parallel_batch = True

--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
@@ -49,6 +49,11 @@ from mask_rcnn.hyperparameters import params_io
 from mask_rcnn.hooks import CheckpointSaverHook
 from mask_rcnn.hooks import PretrainedWeightsLoadingHook
 
+# Sagemaker uses s3 to save model, and since 2.6 s3 support needs tensorflow-io package
+# https://giters.com/tensorflow/tensorflow/issues/51583?amp=1
+from distutils.version import LooseVersion
+if LooseVersion(tf.__version__) >= LooseVersion("2.6"):
+    import tensorflow_io as tfio
 
 def get_training_hooks(mode, model_dir, checkpoint_path=None, skip_checkpoint_variables=None):
 


### PR DESCRIPTION
Port #63 to nccl branch. Note that we do not need to install tfio as DLC training image already has it. The fix should bring TF m-rcnn benchmarking back to live.