### PR TITLE
Fix missing THC headers of MaskRCNN for PT 1.11

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/ROIAlign_cuda.cu
@@ -1,8 +1,7 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-
-#include <THC/THC.h>
+#include <ATen/ceil_div.h>
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 
@@ -272,11 +271,11 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
   auto output_size = num_rois * pooled_height * pooled_width * channels;
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(output_size, 512L), 4096L));
+  dim3 grid(std::min(at::ceil_div(output_size, 512L), 4096L));
   dim3 block(512);
 
   if (output.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
     return output;
   }
 
@@ -294,7 +293,7 @@ at::Tensor ROIAlign_forward_cuda(const at::Tensor& input,
          rois.contiguous().data_ptr<scalar_t>(),
          output.data_ptr<scalar_t>());
   });
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
   return output;
 }
 
@@ -317,12 +316,12 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(grad.numel(), 512L), 4096L));
+  dim3 grid(std::min(at::ceil_div(grad.numel(), 512L), 4096L));
   dim3 block(512);
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
     return grad_input;
   }
 
@@ -341,6 +340,6 @@ at::Tensor ROIAlign_backward_cuda(const at::Tensor& grad,
          grad_input.data_ptr<scalar_t>(),
          rois.contiguous().data_ptr<scalar_t>());
   });
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
   return grad_input;
 }

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/ROIPool_cuda.cu
@@ -1,8 +1,8 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/ceil_div.h>
 
-#include <THC/THC.h>
 #include <THC/THCAtomics.cuh>
 #include <THC/THCDeviceUtils.cuh>
 
@@ -126,11 +126,11 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(output_size, 512L), 4096L));
+  dim3 grid(std::min(at::ceil_div(output_size, 512L), 4096L));
   dim3 block(512);
 
   if (output.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
     return std::make_tuple(output, argmax);
   }
 
@@ -148,7 +148,7 @@ std::tuple<at::Tensor, at::Tensor> ROIPool_forward_cuda(const at::Tensor& input,
          output.data_ptr<scalar_t>(),
          argmax.data_ptr<int>());
   });
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
   return std::make_tuple(output, argmax);
 }
 
@@ -173,12 +173,12 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
 
   cudaStream_t stream = at::cuda::getCurrentCUDAStream();
 
-  dim3 grid(std::min(THCCeilDiv(grad.numel(), 512L), 4096L));
+  dim3 grid(std::min(at::ceil_div(grad.numel(), 512L), 4096L));
   dim3 block(512);
 
   // handle possibly empty gradients
   if (grad.numel() == 0) {
-    THCudaCheck(cudaGetLastError());
+    C10_CUDA_CHECK(cudaGetLastError());
     return grad_input;
   }
 
@@ -197,6 +197,6 @@ at::Tensor ROIPool_backward_cuda(const at::Tensor& grad,
          grad_input.data_ptr<scalar_t>(),
          rois.contiguous().data_ptr<scalar_t>());
   });
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
   return grad_input;
 }

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/box_encode.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/box_encode.cu
@@ -16,7 +16,6 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
 #include <torch/torch.h>
 #include <vector>

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/box_iou.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/box_iou.cu
@@ -16,7 +16,6 @@
 
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
 #include <torch/torch.h>
 #include <iostream>

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/generate_mask_targets.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/generate_mask_targets.cu
@@ -21,7 +21,6 @@
 #include <cuda_runtime.h>
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
-#include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
 #include <math.h>
 #include <algorithm>

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/match_proposals.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/match_proposals.cu
@@ -17,7 +17,6 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
 #include <torch/torch.h>
 #include <vector>

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/nms.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/nms.cu
@@ -1,8 +1,9 @@
 // Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved.
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
+#include <ATen/ceil_div.h>
+#include <c10/cuda/CUDACachingAllocator.h>
 
-#include <THC/THC.h>
 #include <THC/THCDeviceUtils.cuh>
 
 #include <vector>
@@ -61,7 +62,7 @@ __global__ void nms_kernel(const int n_boxes, const float nms_overlap_thresh,
         t |= 1ULL << i;
       }
     }
-    const int col_blocks = THCCeilDiv(n_boxes, threadsPerBlock);
+    const int col_blocks = at::ceil_div(n_boxes, threadsPerBlock);
     dev_mask[cur_box_idx * col_blocks + col_start] = t;
   }
 }
@@ -76,20 +77,22 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
 
   int boxes_num = boxes.size(0);
 
-  const int col_blocks = THCCeilDiv(boxes_num, threadsPerBlock);
+  const int col_blocks = at::ceil_div(boxes_num, threadsPerBlock);
 
   scalar_t* boxes_dev = boxes_sorted.data_ptr<scalar_t>();
 
-  THCState *state = at::globalContext().lazyInitCUDA(); // TODO replace with getTHCState
+  //THCState *state = at::globalContext().lazyInitCUDA(); // TODO replace with getTHCState
+  at::globalContext().lazyInitCUDA();
 
   unsigned long long* mask_dev = NULL;
   //THCudaCheck(THCudaMalloc(state, (void**) &mask_dev,
   //                      boxes_num * col_blocks * sizeof(unsigned long long)));
 
-  mask_dev = (unsigned long long*) THCudaMalloc(state, boxes_num * col_blocks * sizeof(unsigned long long));
+  mask_dev = (unsigned long long *) c10::cuda::CUDACachingAllocator::raw_alloc(
+      boxes_num * col_blocks * sizeof(unsigned long long));
 
-  dim3 blocks(THCCeilDiv(boxes_num, threadsPerBlock),
-              THCCeilDiv(boxes_num, threadsPerBlock));
+  dim3 blocks(at::ceil_div(boxes_num, threadsPerBlock),
+              at::ceil_div(boxes_num, threadsPerBlock));
   dim3 threads(threadsPerBlock);
   nms_kernel<<<blocks, threads>>>(boxes_num,
                                   nms_overlap_thresh,
@@ -97,7 +100,7 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
                                   mask_dev);
 
   std::vector<unsigned long long> mask_host(boxes_num * col_blocks);
-  THCudaCheck(cudaMemcpy(&mask_host[0],
+  C10_CUDA_CHECK(cudaMemcpy(&mask_host[0],
                         mask_dev,
                         sizeof(unsigned long long) * boxes_num * col_blocks,
                         cudaMemcpyDeviceToHost));
@@ -122,7 +125,7 @@ at::Tensor nms_cuda(const at::Tensor boxes, float nms_overlap_thresh) {
     }
   }
 
-  THCudaFree(state, mask_dev);
+  c10::cuda::CUDACachingAllocator::raw_delete(mask_dev);
   // TODO improve this part
   return std::get<0>(order_t.index({
                        keep.narrow(/*dim=*/0, /*start=*/0, /*length=*/num_to_keep).to(

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/rpn_generate_proposals.cu
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/rpn_generate_proposals.cu
@@ -18,8 +18,6 @@
 #include <ATen/ATen.h>
 #include <ATen/cuda/CUDAContext.h>
 
-#include <THC/THC.h>
-
 namespace rpn {
 namespace {
 
@@ -223,7 +221,7 @@ std::vector<at::Tensor> GeneratePreNMSUprightBoxes(
           pre_nms_nboxes,
           sorted_scores.data_ptr<float>(),
           boxes_keep_flags.data_ptr<uint8_t>());
-  THCudaCheck(cudaGetLastError());
+  C10_CUDA_CHECK(cudaGetLastError());
 
   return std::vector<at::Tensor>{boxes, sorted_scores, boxes_keep_flags};
 }

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/rpn_generate_proposals.h
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/csrc/cuda/rpn_generate_proposals.h
@@ -17,7 +17,6 @@
 #pragma once
 
 #include <ATen/ATen.h>
-#include <THC/THC.h>
 
 #include <vector>
 


### PR DESCRIPTION
Merge after PT1.11 DLC release.
Please make sure all DLC with PT < 1.11 use the `release/Pre_PT_1.11` branch.