### PR TITLE
fix maskrcnn nccl branch for TF2.9

### DIFF
--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
@@ -214,7 +214,8 @@ class BaseExecuter(object):
 
           elif not use_tf_distributed:
               config.inter_op_parallelism_threads = 4
-
+      
+      config.gpu_options.allow_growth = True
       return config
 
   @abc.abstractmethod

--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/mask_rcnn_model.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/mask_rcnn_model.py
@@ -71,7 +71,7 @@ def create_optimizer(learning_rate, params):
         )
 
     if params["amp"]:
-        loss_scale = tf.train.experimental.DynamicLossScale(
+        loss_scale = tf.compat.v1.train.experimental.DynamicLossScale(
             initial_loss_scale=(2 ** 12),
             increment_period=2000,
             multiplier=2.0


### PR DESCRIPTION
1. TF2.9 deprecated Loss Scale classes : https://github.com/tensorflow/tensorflow/commit/bf1048b38366d97c37774d84f98df295585a5535. This affects Maskrcnn runs because DynamicLossScale is no longer accessible from tf.train.experimental. Had to rename tf.train.experimental.DynamicLossScale ==> tf.compat.v1.train.experimental.DynamicLossScale

2. cuDNN failures: bad error message, actual cause was OOM. Fixed with config.gpu_options.allow_growth = True