### PR TITLE
Fix MaskRCNN benchmark script to use PT DDP instead of apex

### DIFF
--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/model_zoo.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/model_zoo.py
@@ -3,11 +3,11 @@ import os
 import sys
 
 try:
-    from torch.utils.model_zoo import download_url_to_file
+    from torch.utils.model_zoo import _download_url_to_file
     from torch.utils.model_zoo import urlparse
     from torch.utils.model_zoo import HASH_REGEX
 except:
-    from torch.hub import _download_url_to_file
+    from torch.hub import download_url_to_file
     from torch.hub import urlparse
     from torch.hub import HASH_REGEX
 

--- a/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/model_zoo.py
+++ b/PyTorch/Segmentation/MaskRCNN/pytorch/maskrcnn_benchmark/utils/model_zoo.py
@@ -3,7 +3,7 @@ import os
 import sys
 
 try:
-    from torch.utils.model_zoo import _download_url_to_file
+    from torch.utils.model_zoo import download_url_to_file
     from torch.utils.model_zoo import urlparse
     from torch.utils.model_zoo import HASH_REGEX
 except:


### PR DESCRIPTION
### Description
MaskRCNN NCCL benchmark scripts are failing due to apex DDP import.

### Testing
Successful run with following code change: https://us-west-2.console.aws.amazon.com/sagemaker/home?region=us-west-2#/jobs/cu113-pt-p4d-2-68YB-2022-09-18-18-30-08-407

### References
Tracking ticket: https://t.corp.amazon.com/V630070663/communication