### PR TITLE
Fix for MaskRCNN error: device mapped to multiple devices

### DIFF
--- a/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
+++ b/TensorFlow2/Segmentation/MaskRCNN/mask_rcnn/distributed_executer.py
@@ -29,9 +29,18 @@ import math
 
 import multiprocessing
 
-import tensorflow as tf
 import smdistributed.dataparallel.tensorflow as hvd
 hvd.init()
+
+# Fix for compatibility with TF 2.11.
+# We need to set the visible GPUs at the top of the script, otherwise we get error
+# AlreadyExistsError: TensorFlow device is being mapped to multiple devices, which is not supported.
+import tensorflow as tf
+gpus = tf.config.experimental.list_physical_devices("GPU")
+for gpu in gpus:
+    tf.config.experimental.set_memory_growth(gpu, True)
+if gpus:
+    tf.config.experimental.set_visible_devices(gpus[hvd.local_rank()], "GPU")
 
 from mask_rcnn.utils.logging_formatter import logging
 


### PR DESCRIPTION
## Justification
After the DLC was updated to TF 2.11, we started to get error:
```
tensorflow.python.framework.errors_impl.AlreadyExistsError: TensorFlow device (GPU:0) is being mapped to multiple devices (7 now, and 0 previously), which is not supported. This may be the result of providing different GPU configurations (ConfigProto.gpu_options, for example different visible_device_list) when creating multiple Sessions in the same process. This is not currently supported, see https://github.com/tensorflow/tensorflow/issues/19083
```

After some research, we found that the issue is associated to the way in which TF provides visibility for the GPU devices. We followed the recommendations from https://github.com/horovod/horovod/issues/676#issuecomment-504988278 and fixed the issue.

## Implementation
- Explicitly set the visible devices at the top of the script using `tf.config.experimental.set_visible_devices`
## Testing
- Ran MaskRCNN distributed training using pcluster with 4 and 8 nodes on a DLC with TF 2.11 and training finished successfully.